### PR TITLE
Add platform specific extensions

### DIFF
--- a/DominantColor.xcodeproj/project.pbxproj
+++ b/DominantColor.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		723DE5C71A4939A500C357E3 /* INVector3.m in Sources */ = {isa = PBXBuildFile; fileRef = 723DE5191A49348D00C357E3 /* INVector3.m */; };
 		72431C0F1A4BCF3B00470BD7 /* INVector3SwiftExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72431C0E1A4BCF3B00470BD7 /* INVector3SwiftExtensions.swift */; };
 		72431C101A4BCF3B00470BD7 /* INVector3SwiftExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72431C0E1A4BCF3B00470BD7 /* INVector3SwiftExtensions.swift */; };
+		724C2DCD1A4CD64600472402 /* PlatformExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724C2DCC1A4CD64600472402 /* PlatformExtensions.swift */; };
+		724C2DCE1A4CD64600472402 /* PlatformExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724C2DCC1A4CD64600472402 /* PlatformExtensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -114,6 +116,7 @@
 		723DE59F1A4938DD00C357E3 /* DominantColor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DominantColor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		723DE5BE1A49394D00C357E3 /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.1.sdk/System/Library/Frameworks/GLKit.framework; sourceTree = DEVELOPER_DIR; };
 		72431C0E1A4BCF3B00470BD7 /* INVector3SwiftExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = INVector3SwiftExtensions.swift; sourceTree = "<group>"; };
+		724C2DCC1A4CD64600472402 /* PlatformExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlatformExtensions.swift; sourceTree = "<group>"; };
 		72D797B81A43F44D00D32E7C /* ExampleMac.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExampleMac.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		72D797DE1A43F89000D32E7C /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
 		898845D21A490CE000003EF2 /* ExampleiOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExampleiOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -160,13 +163,14 @@
 			children = (
 				723DE5581A49358F00C357E3 /* DominantColor.h */,
 				723DE5141A49348D00C357E3 /* ColorDifference.swift */,
-				723DE5151A49348D00C357E3 /* ColorSpaceConversion.h */,
-				723DE5161A49348D00C357E3 /* ColorSpaceConversion.m */,
 				723DE5171A49348D00C357E3 /* DominantColors.swift */,
-				723DE5181A49348D00C357E3 /* INVector3.h */,
-				723DE5191A49348D00C357E3 /* INVector3.m */,
 				72431C0E1A4BCF3B00470BD7 /* INVector3SwiftExtensions.swift */,
 				723DE51A1A49348D00C357E3 /* KMeans.swift */,
+				724C2DCC1A4CD64600472402 /* PlatformExtensions.swift */,
+				723DE5151A49348D00C357E3 /* ColorSpaceConversion.h */,
+				723DE5161A49348D00C357E3 /* ColorSpaceConversion.m */,
+				723DE5181A49348D00C357E3 /* INVector3.h */,
+				723DE5191A49348D00C357E3 /* INVector3.m */,
 				723DE5381A49353C00C357E3 /* Supporting Files */,
 				2F3D09851A4C212A001ED0BF /* Memoization.swift */,
 			);
@@ -445,6 +449,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				724C2DCD1A4CD64600472402 /* PlatformExtensions.swift in Sources */,
 				2F3D09861A4C212A001ED0BF /* Memoization.swift in Sources */,
 				723DE55C1A49360F00C357E3 /* ColorDifference.swift in Sources */,
 				72431C0F1A4BCF3B00470BD7 /* INVector3SwiftExtensions.swift in Sources */,
@@ -459,6 +464,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				724C2DCE1A4CD64600472402 /* PlatformExtensions.swift in Sources */,
 				2F3D09871A4C212A001ED0BF /* Memoization.swift in Sources */,
 				723DE5C31A49399E00C357E3 /* ColorDifference.swift in Sources */,
 				72431C101A4BCF3B00470BD7 /* INVector3SwiftExtensions.swift in Sources */,

--- a/DominantColor/Shared/DominantColors.swift
+++ b/DominantColor/Shared/DominantColors.swift
@@ -85,11 +85,17 @@ public enum GroupingAccuracy {
     case High       // CIE 2000 - Additional corrections for neutral colors, lightness, chroma, and hue
 }
 
+struct DefaultParameterValues {
+    static var maxSampledPixels: UInt = 1000
+    static var accuracy: GroupingAccuracy = .Medium
+    static var seed: UInt32 = 3571
+}
+
 public func dominantColorsInImage(
         image: CGImage,
-        maxSampledPixels: UInt = 1000,
-        accuracy: GroupingAccuracy = .Medium,
-        seed: UInt32 = 3571
+        maxSampledPixels: UInt = DefaultParameterValues.maxSampledPixels,
+        accuracy: GroupingAccuracy = DefaultParameterValues.accuracy,
+        seed: UInt32 = DefaultParameterValues.seed
     ) -> [CGColor] {
     
     let (width, height) = (CGImageGetWidth(image), CGImageGetHeight(image))

--- a/DominantColor/Shared/PlatformExtensions.swift
+++ b/DominantColor/Shared/PlatformExtensions.swift
@@ -1,0 +1,39 @@
+//
+//  PlatformExtensions.swift
+//  DominantColor
+//
+//  Created by Indragie on 12/25/14.
+//  Copyright (c) 2014 Indragie Karunaratne. All rights reserved.
+//
+
+#if os(OSX)
+import Cocoa
+
+public extension NSImage {
+    public func dominantColors(
+        maxSampledPixels: UInt = DefaultParameterValues.maxSampledPixels,
+        accuracy: GroupingAccuracy = DefaultParameterValues.accuracy,
+        seed: UInt32 = DefaultParameterValues.seed
+    ) -> [NSColor] {
+        let image = CGImageForProposedRect(nil, context: nil, hints: nil)!.takeUnretainedValue()
+        let colors = dominantColorsInImage(image, maxSampledPixels: maxSampledPixels, accuracy: accuracy, seed: seed)
+        return colors.map { NSColor(CGColor: $0) }
+    }
+}
+
+#elseif os(iOS)
+import UIKit
+
+public extension UIImage {
+    public func dominantColors(
+        maxSampledPixels: UInt = DefaultParameterValues.maxSampledPixels,
+        accuracy: GroupingAccuracy = DefaultParameterValues.accuracy,
+        seed: UInt32 = DefaultParameterValues.seed
+    ) -> [UIColor] {
+        let colors = dominantColorsInImage(self.CGImage, maxSampledPixels: maxSampledPixels, accuracy: accuracy, seed: seed)
+        return colors.map { UIColor(CGColor: $0) }
+    }
+}
+
+#endif
+


### PR DESCRIPTION
These make it super easy to get dominant colors from the platform native `UIImage` and `NSImage` types. `image.dominantColors()` is all it takes.
