### PR TITLE
Using Int(v) instead of v.hashValue for hash combo

### DIFF
--- a/DominantColor/Shared/DominantColors.swift
+++ b/DominantColor/Shared/DominantColors.swift
@@ -23,7 +23,7 @@ private struct RGBAPixel {
 
 extension RGBAPixel: Hashable {
     private var hashValue: Int {
-        return (((r.hashValue << 8) | g.hashValue) << 8) | b.hashValue
+        return (((Int(r) << 8) | Int(g)) << 8) | Int(b)
     }
 }
 


### PR DESCRIPTION
Deduced From the offline discussion with Indragie, Int(v)
will apparently shave some ms off ~3.
Int(v) was the original form but was changed for readability.
