### PR TITLE
iOS Xcode 6.3 support

### DIFF
--- a/DominantColor/Shared/ColorDifference.swift
+++ b/DominantColor/Shared/ColorDifference.swift
@@ -12,9 +12,9 @@ import GLKit.GLKMath
 // calculations it doesn't matter and saves an unnecessary computation.
 
 // From http://www.brucelindbloom.com/index.html?Eqn_DeltaE_CIE76.html
-func CIE76SquaredColorDifference(colors: (INVector3, INVector3)) -> Float {
-    let (L1, a1, b1) = colors.0.unpack()
-    let (L2, a2, b2) = colors.1.unpack()
+func CIE76SquaredColorDifference(lab1: INVector3, lab2: INVector3) -> Float {
+    let (L1, a1, b1) = lab1.unpack()
+    let (L2, a2, b2) = lab2.unpack()
     
     return pow(L2 - L1, 2) + pow(a2 - a1, 2) + pow(b2 - b1, 2)
 }
@@ -30,10 +30,10 @@ func CIE94SquaredColorDifference(
         kH: Float = 1,
         K1: Float = 0.045,
         K2: Float = 0.015
-    )(colors: (INVector3, INVector3)) -> Float {
+    )(lab1:INVector3, lab2:INVector3) -> Float {
     
-    let (L1, a1, b1) = colors.0.unpack()
-    let (L2, a2, b2) = colors.1.unpack()
+    let (L1, a1, b1) = lab1.unpack()
+    let (L2, a2, b2) = lab2.unpack()
     let ΔL = L1 - L2
         
     let (C1, C2) = (C(a1, b1), C(a2, b2))
@@ -53,10 +53,10 @@ func CIE2000SquaredColorDifference(
         kL: Float = 1,
         kC: Float = 1,
         kH: Float = 1
-    )(colors: (INVector3, INVector3)) -> Float {
+    )(lab1:INVector3, lab2:INVector3) -> Float {
         
-    let (L1, a1, b1) = colors.0.unpack()
-    let (L2, a2, b2) = colors.1.unpack()
+    let (L1, a1, b1) = lab1.unpack()
+    let (L2, a2, b2) = lab2.unpack()
     
     let ΔLp = L2 - L1
     let Lbp = (L1 + L2) / 2

--- a/DominantColor/Shared/ColorDifference.swift
+++ b/DominantColor/Shared/ColorDifference.swift
@@ -12,9 +12,9 @@ import GLKit.GLKMath
 // calculations it doesn't matter and saves an unnecessary computation.
 
 // From http://www.brucelindbloom.com/index.html?Eqn_DeltaE_CIE76.html
-func CIE76SquaredColorDifference(lab1: INVector3, lab2: INVector3) -> Float {
-    let (L1, a1, b1) = lab1.unpack()
-    let (L2, a2, b2) = lab2.unpack()
+func CIE76SquaredColorDifference(colors: (INVector3, INVector3)) -> Float {
+    let (L1, a1, b1) = colors.0.unpack()
+    let (L2, a2, b2) = colors.1.unpack()
     
     return pow(L2 - L1, 2) + pow(a2 - a1, 2) + pow(b2 - b1, 2)
 }

--- a/DominantColor/Shared/DominantColors.swift
+++ b/DominantColor/Shared/DominantColors.swift
@@ -161,9 +161,9 @@ private func distanceForAccuracy(accuracy: GroupingAccuracy) -> (INVector3, INVe
     case .Low:
         return CIE76SquaredColorDifference
     case .Medium:
-        return { CIE94SquaredColorDifference()(colors: $0) }
+        return CIE94SquaredColorDifference()
     case .High:
-        return { CIE2000SquaredColorDifference()(colors: $0) }
+        return CIE2000SquaredColorDifference()
     }
 }
 

--- a/DominantColor/Shared/DominantColors.swift
+++ b/DominantColor/Shared/DominantColors.swift
@@ -31,7 +31,7 @@ private func ==(lhs: RGBAPixel, rhs: RGBAPixel) -> Bool {
     return lhs.r == rhs.r && lhs.g == rhs.g && lhs.b == rhs.b
 }
 
-private func createRGBAContext(width: UInt, height: UInt) -> CGContext {
+private func createRGBAContext(width: Int, height: Int) -> CGContext {
     return CGBitmapContextCreate(
         nil,
         width,
@@ -47,7 +47,7 @@ private func createRGBAContext(width: UInt, height: UInt) -> CGContext {
 // in the order that they are stored in memory, for faster access.
 //
 // From: https://www.mikeash.com/pyblog/friday-qa-2012-08-31-obtaining-and-interpreting-image-data.html
-private func enumerateRGBAContext(context: CGContext, handler: (UInt, UInt, RGBAPixel) -> Void) {
+private func enumerateRGBAContext(context: CGContext, handler: (Int, Int, RGBAPixel) -> Void) {
     let (width, height) = (CGBitmapContextGetWidth(context), CGBitmapContextGetHeight(context))
     let data = unsafeBitCast(CGBitmapContextGetData(context), UnsafeMutablePointer<RGBAPixel>.self)
     for y in 0..<height {
@@ -86,7 +86,7 @@ public enum GroupingAccuracy {
 }
 
 struct DefaultParameterValues {
-    static var maxSampledPixels: UInt = 1000
+    static var maxSampledPixels: Int = 1000
     static var accuracy: GroupingAccuracy = .Medium
     static var seed: UInt32 = 3571
     static var memoizeConversions: Bool = false
@@ -116,7 +116,7 @@ Computes the dominant colors in an image
 */
 public func dominantColorsInImage(
         image: CGImage,
-        maxSampledPixels: UInt = DefaultParameterValues.maxSampledPixels,
+        maxSampledPixels: Int = DefaultParameterValues.maxSampledPixels,
         accuracy: GroupingAccuracy = DefaultParameterValues.accuracy,
         seed: UInt32 = DefaultParameterValues.seed,
         memoizeConversions: Bool = DefaultParameterValues.memoizeConversions
@@ -161,19 +161,19 @@ private func distanceForAccuracy(accuracy: GroupingAccuracy) -> (INVector3, INVe
     case .Low:
         return CIE76SquaredColorDifference
     case .Medium:
-        return CIE94SquaredColorDifference()
+        return { CIE94SquaredColorDifference()(colors: $0) }
     case .High:
-        return CIE2000SquaredColorDifference()
+        return { CIE2000SquaredColorDifference()(colors: $0) }
     }
 }
 
 // Computes the proportionally scaled dimensions such that the
 // total number of pixels does not exceed the specified limit.
-private func scaledDimensionsForPixelLimit(limit: UInt, width: UInt, height: UInt) -> (UInt, UInt) {
+private func scaledDimensionsForPixelLimit(limit: Int, width: Int, height: Int) -> (Int, Int) {
     if (width * height > limit) {
         let ratio = Float(width) / Float(height)
         let maxWidth = sqrtf(ratio * Float(limit))
-        return (UInt(maxWidth), UInt(Float(limit) / maxWidth))
+        return (Int(maxWidth), Int(Float(limit) / maxWidth))
     }
     return (width, height)
 }

--- a/DominantColor/Shared/KMeans.swift
+++ b/DominantColor/Shared/KMeans.swift
@@ -16,7 +16,7 @@ protocol ClusteredType {
     func /(lhs: Self, rhs: Int) -> Self
     
     // Identity value such that x + identity = x. Typically the 0 vector.
-    class var identity: Self { get }
+    static var identity: Self { get }
 }
 
 struct Cluster<T : ClusteredType> {
@@ -35,10 +35,10 @@ func kmeans<T : ClusteredType>(
         threshold: Float = 0.0001
     ) -> [Cluster<T>] {
             
-    let n = countElements(points)
+    let n = count(points)
     assert(k <= n, "k cannot be larger than the total number of points")
 
-    var centroids = points.randomValues(seed, count: k)
+    var centroids = points.randomValues(seed, num: k)
     var memberships = [Int](count: n, repeatedValue: -1)
     var clusterSizes = [Int](count: k, repeatedValue: 0)
     
@@ -99,13 +99,13 @@ private func randomNumberInRange(range: Range<Int>) -> Int {
 }
 
 private extension Array {
-    private func randomValues(seed: UInt32, count: Int) -> [T] {
+    private func randomValues(seed: UInt32, num: Int) -> [T] {
         srand(seed)
         
         var indices = [Int]()
-        indices.reserveCapacity(count)
-        let range = 0..<countElements(self)
-        for i in 0..<count {
+        indices.reserveCapacity(num)
+        let range = 0..<self.count
+        for i in 0..<num {
             var random = 0
             do {
                 random = randomNumberInRange(range)

--- a/DominantColor/Shared/PlatformExtensions.swift
+++ b/DominantColor/Shared/PlatformExtensions.swift
@@ -69,13 +69,13 @@ public extension UIImage {
               least dominant.
     */
     public func dominantColors(
-        maxSampledPixels: UInt = DefaultParameterValues.maxSampledPixels,
+        maxSampledPixels: Int = DefaultParameterValues.maxSampledPixels,
         accuracy: GroupingAccuracy = DefaultParameterValues.accuracy,
         seed: UInt32 = DefaultParameterValues.seed,
         memoizeConversions: Bool = DefaultParameterValues.memoizeConversions
     ) -> [UIColor] {
         let colors = dominantColorsInImage(self.CGImage, maxSampledPixels: maxSampledPixels, accuracy: accuracy, seed: seed, memoizeConversions: memoizeConversions)
-        return colors.map { UIColor(CGColor: $0) }
+        return colors.map { UIColor(CGColor: $0)! }
     }
 }
 

--- a/DominantColor/iOS/ExampleiOS-Bridging-Header.h
+++ b/DominantColor/iOS/ExampleiOS-Bridging-Header.h
@@ -2,4 +2,5 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 
+#include <stdint.h>
 extern uint64_t dispatch_benchmark(size_t count, void (^block)(void));

--- a/DominantColor/iOS/ViewController.swift
+++ b/DominantColor/iOS/ViewController.swift
@@ -27,7 +27,7 @@ class ViewController: UIViewController , UIImagePickerControllerDelegate, UINavi
     
     @IBAction func runBenchmarkTapped(sender: AnyObject) {
         if let image = image {
-            let nValues: [UInt] = [100, 1000, 2000, 5000, 10000]
+            let nValues: [Int] = [100, 1000, 2000, 5000, 10000]
             let CGImage = image.CGImage
             for n in nValues {
                 let ns = dispatch_benchmark(5) {
@@ -41,7 +41,7 @@ class ViewController: UIViewController , UIImagePickerControllerDelegate, UINavi
     
     // MARK: ImagePicker Delegate
     
-    func imagePickerController(picker: UIImagePickerController!, didFinishPickingImage image: UIImage!, editingInfo: [NSObject : AnyObject]!) {
+    func imagePickerController(picker: UIImagePickerController, didFinishPickingImage image: UIImage!, editingInfo: [NSObject : AnyObject]!) {
         if let imageSelected = image {
             self.image = imageSelected
             imageView.image = imageSelected
@@ -50,7 +50,7 @@ class ViewController: UIViewController , UIImagePickerControllerDelegate, UINavi
             for box in boxes {
                 box.backgroundColor = UIColor.clearColor()
             }
-            for i in 0..<min(countElements(colors), countElements(boxes)) {
+            for i in 0..<min(colors.count, boxes.count) {
                 boxes[i].backgroundColor = colors[i]
             }
         }


### PR DESCRIPTION
I've attempted to update the Example App for iOS to support XCode 6.3 and Swift 1.2

Mostly it seemed to be XCode 6.3 prefers Int to UInt, and a few other calls around countElements(Array) which generally become Array.count.

I did not attempt to update the Mac example App.