### PR TITLE
Use seed in random generator + Swift 4 Update

### DIFF
--- a/DominantColor.podspec
+++ b/DominantColor.podspec
@@ -8,8 +8,8 @@ Pod::Spec.new do |spec|
 	spec.source = { :git => 'https://github.com/indragiek/DominantColor.git', :tag => spec.version.to_s }
 	spec.source_files = 'DominantColor/Shared/*.{swift,h,m}'
 	spec.requires_arc = true
-	spec.frameworks = 'GLKit'
-	spec.ios.deployment_target = '8.0'
+	spec.frameworks = ['GLKit', 'GameKit']
+	spec.ios.deployment_target = '9.0'
 	spec.osx.deployment_target = '10.9'
 	spec.ios.frameworks = 'UIKit'
 	spec.osx.frameworks = 'Cocoa'

--- a/DominantColor.xcodeproj/project.pbxproj
+++ b/DominantColor.xcodeproj/project.pbxproj
@@ -612,7 +612,6 @@
 				PRODUCT_NAME = DominantColor;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -636,7 +635,6 @@
 				PRODUCT_NAME = DominantColor;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -688,7 +686,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -729,7 +727,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/DominantColor/Shared/DominantColors.swift
+++ b/DominantColor/Shared/DominantColors.swift
@@ -85,11 +85,11 @@ public enum GroupingAccuracy {
     case high       // CIE 2000 - Additional corrections for neutral colors, lightness, chroma, and hue
 }
 
-struct DefaultParameterValues {
-    static var maxSampledPixels: Int = 1000
-    static var accuracy: GroupingAccuracy = .medium
-    static var seed: UInt32 = 3571
-    static var memoizeConversions: Bool = false
+public struct DefaultParameterValues {
+    public static var maxSampledPixels: Int = 1000
+    public static var accuracy: GroupingAccuracy = .medium
+    public static var seed: UInt32 = 3571
+    public static var memoizeConversions: Bool = false
 }
 
 /**

--- a/DominantColor/Shared/DominantColors.swift
+++ b/DominantColor/Shared/DominantColors.swift
@@ -88,7 +88,7 @@ public enum GroupingAccuracy {
 public struct DefaultParameterValues {
     public static var maxSampledPixels: Int = 1000
     public static var accuracy: GroupingAccuracy = .medium
-    public static var seed: UInt32 = 3571
+    public static var seed: UInt64 = 3571
     public static var memoizeConversions: Bool = false
 }
 
@@ -118,7 +118,7 @@ public func dominantColorsInImage(
         _ image: CGImage,
         maxSampledPixels: Int = DefaultParameterValues.maxSampledPixels,
         accuracy: GroupingAccuracy = DefaultParameterValues.accuracy,
-        seed: UInt32 = DefaultParameterValues.seed,
+        seed: UInt64 = DefaultParameterValues.seed,
         memoizeConversions: Bool = DefaultParameterValues.memoizeConversions
     ) -> [CGColor] {
     

--- a/DominantColor/Shared/PlatformExtensions.swift
+++ b/DominantColor/Shared/PlatformExtensions.swift
@@ -71,7 +71,7 @@ public extension UIImage {
     public func dominantColors(
         _ maxSampledPixels: Int = DefaultParameterValues.maxSampledPixels,
         accuracy: GroupingAccuracy = DefaultParameterValues.accuracy,
-        seed: UInt32 = DefaultParameterValues.seed,
+        seed: UInt64 = DefaultParameterValues.seed,
         memoizeConversions: Bool = DefaultParameterValues.memoizeConversions
     ) -> [UIColor] {
         if let CGImage = self.cgImage {


### PR DESCRIPTION
Hey 👋 

Noticed that we can pass in a seed for the random generator, however its never actually used. This PR primarily adds support to use that seed and ensure that colour values returned are the same for the same seed.

It also sets the swift language version to 4.0, which required making the default values public. Please let me know if you'd like that change submitted as a separate PR, and if you'd like it implemented in a different way.

Cheers!