### PR TITLE
Fixing issue for Carthage Support

### DIFF
--- a/DominantColor/Mac/Info.plist
+++ b/DominantColor/Mac/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>APPL</string>
+	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleSignature</key>

--- a/DominantColor/iOS/Info.plist
+++ b/DominantColor/iOS/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>APPL</string>
+	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleSignature</key>


### PR DESCRIPTION
* the info.plist are specifying the wrong bundle package type, it should be Framework instead of Application.